### PR TITLE
Add static assertion on CfpaPage size.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,16 @@ dependencies = [
  "lpc55-pac",
  "num-derive",
  "num-traits",
+ "static_assertions",
  "tinycrc",
  "zerocopy",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hex-literal = "0.3.4"
 lpc55-pac = { version = "0.5.0", features = ["rt"] }
 num-derive = { version = "0.3.3", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
+static_assertions = "1.1.0"
 tinycrc = {path = "tinycrc"}
 zerocopy = { version = "0.6.1", default-features = false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,8 @@ pub struct NxpImageHeader {
 ///
 /// This struct should be exactly 512 bytes. If you change it such that its size
 /// is no longer 512 bytes, it will not compromise security, but stage0 will
-/// panic while checking the persistent settings.
+/// panic while checking the persistent settings (and with any luck the static
+/// assertion below will fire before you hit the panic).
 #[derive(Copy, Clone, Debug, AsBytes, FromBytes)]
 #[repr(C)]
 pub struct CfpaPage {
@@ -373,6 +374,10 @@ pub struct CfpaPage {
     // down if you add fields.
     _padding: [u8; 252],
 }
+
+// It's really quite important that the CFPA data structure be exactly the size
+// of a flash page, 512 bytes.
+static_assertions::const_assert_eq!(size_of::<CfpaPage>(), 512);
 
 /// Checks if the page containing `word_number` has been programmed since it was
 /// last erased. Since reading from an erased page will fault, it's important to


### PR DESCRIPTION
From @mkeeter's review feedback: ensure that the `CfpaPage` struct is kept to 512 bytes by something other than a pleading comment.