### PR TITLE
Clamp FLASH size to 8K to match Hubris

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -1,6 +1,10 @@
 MEMORY {
-    FLASH (rx): ORIGIN = 0x10000000, LENGTH = 24K
-    DATAFLASH (rw): ORIGIN = 0x10000000 + 24K, LENGTH = 8K
+    /*
+     * This length should be coordinated with Hubris!  During bootleby updates,
+     * Hubris writes the new bootleby image to flash offset 0x2000, so bootleby
+     * should not exceed that length (otherwise its tail will be overwritten).
+     */
+    FLASH (rx): ORIGIN = 0x10000000, LENGTH = 8K
 
     /*
      * Note: RAM is offset by 0x4000 because the Boot ROM uses that area


### PR DESCRIPTION
The hash of `target/thumbv8m.main-none-eabihf/release/bootleby` doesn't change, so this should be innocuous (but prevents us from being Unpleasantly Surprised further down the line)