### PR TITLE
Fix typo in length of image_b section

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -68,7 +68,7 @@ SECTIONS {
     } >IMAGE_A
     .image_b ORIGIN(IMAGE_B) (NOLOAD): {
         IMAGE_B = .;
-        . += LENGTH(IMAGE_A);
+        . += LENGTH(IMAGE_B);
     } >IMAGE_B
     .override ORIGIN(OVERRIDE) (NOLOAD): {
         TRANSIENT_OVERRIDE = .;


### PR DESCRIPTION
The `image_b` placeholder was defined to be the length of `IMAGE_A`, which is harmless because A and B are the same size. But we might as well fix that.